### PR TITLE
re-hack the hack

### DIFF
--- a/src/components/Trend/Trend.helpers.js
+++ b/src/components/Trend/Trend.helpers.js
@@ -37,7 +37,7 @@ export const normalizeDataset = (data, maxValue = 0, { minX, maxX, minY, maxY })
   // the dataset. As ugly as it is, it's the best solution we can find (there
   // are ways within the SVG spec of changing it, but not without causing
   // breaking changes).
-  if (boundariesY.min === boundariesY.max) {
+  if (boundariesY.min === normalizedMax) {
     // eslint-disable-next-line no-param-reassign
     normalizedData[0].y += 0.0001;
   }


### PR DESCRIPTION
Since the introduction of our `maxValue` prop, we lost the react-trend hack that fixes an issue with SVGs not rendering if the path is a straight line. This PR puts that hack back in so we can get straight lines back :)